### PR TITLE
set bar width in mixed chart- with bar

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
     env_file: docker/.env
     build:
       <<: *common-build
-    container_name: superset_app
+    container_name: superset_app_fork
     command: ["/app/docker/docker-bootstrap.sh", "app"]
     restart: unless-stopped
     ports:
@@ -143,8 +143,9 @@ services:
     user: *superset-user
     volumes: *superset-volumes
     environment:
+      SUPERSET_LOAD_EXAMPLES: "no"
       CYPRESS_CONFIG: "${CYPRESS_CONFIG:-}"
-      SUPERSET_LOAD_EXAMPLES: "${SUPERSET_LOAD_EXAMPLES:-yes}"
+      # SUPERSET_LOAD_EXAMPLES: "${SUPERSET_LOAD_EXAMPLES:-yes}"
       SUPERSET_LOG_LEVEL: "${SUPERSET_LOG_LEVEL:-info}"
     healthcheck:
       disable: true
@@ -162,7 +163,7 @@ services:
     environment:
       # set this to false if you have perf issues running the npm i; npm run dev in-docker
       # if you do so, you have to run this manually on the host, which should perform better!
-      BUILD_SUPERSET_FRONTEND_IN_DOCKER: true
+      BUILD_SUPERSET_FRONTEND_IN_DOCKER: false
       NPM_RUN_PRUNE: false
       SCARF_ANALYTICS: "${SCARF_ANALYTICS:-}"
       # configuring the dev-server to use the host.docker.internal to connect to the backend

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -158,6 +158,21 @@ function createCustomizeSection(
     ],
     [
       {
+        name: `barWidth${controlSuffix}`,
+        config: {
+          type: 'TextControl',
+          label: t('Bar Width'),
+          description: t('Width of bars in pixels'),
+          default: 5,
+          renderTrigger: true,
+          visibility: ({ controls }) =>
+            controls[`seriesType${controlSuffix}`]?.value ===
+            EchartsTimeseriesSeriesType.Bar,
+        },
+      },
+    ],
+    [
+      {
         name: `stack${controlSuffix}`,
         config: {
           type: 'CheckboxControl',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -412,6 +412,9 @@ export default function transformProps(
         timeShiftColor,
       },
     );
+    if (transformedSeries && seriesType === EchartsTimeseriesSeriesType.Bar) {
+      (transformedSeries as echarts.BarSeriesOption).barWidth = formData.barWidth;
+    }
     if (transformedSeries) series.push(transformedSeries);
   });
 
@@ -462,6 +465,10 @@ export default function transformProps(
         timeShiftColor,
       },
     );
+    if (transformedSeries && seriesTypeB === EchartsTimeseriesSeriesType.Bar) {
+      (transformedSeries as echarts.BarSeriesOption).barWidth =
+        formData.barWidthB ?? formData.barWidth;
+    }
     if (transformedSeries) series.push(transformedSeries);
   });
 


### PR DESCRIPTION

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes in the superset-frontend to allow the superset users to provide a custom width to the bar inside the bar charts -- in case the bar chart is a part of the echarts->  timeseries mixed chart.


